### PR TITLE
14 mejorar precision al firmar el pdf guardar lat y log y refrescar mapa al editar la ubicacion

### DIFF
--- a/app/Livewire/DetallesObras/EditarDetalleObra.php
+++ b/app/Livewire/DetallesObras/EditarDetalleObra.php
@@ -7,7 +7,6 @@ use App\Models\Pais;
 use App\Models\Estado;
 use App\Models\EstadoObra;
 use App\Models\Obra;
-
 use App\Livewire\DetallesObras\DetallesObrasTable;
 use Illuminate\Support\Facades\Auth;
 
@@ -17,31 +16,12 @@ class EditarDetalleObra extends ServicesComponent
     $fechaFin,$calle,$manzana,$lote,$metrosCuadrados,
     $fraccionamiento,$dictamenUsoSuelo, $estados, $paises, $paisSeleccionado, $estadoSeleccionado,
     $estadosObra, $estadoObraSeleccionado;
+    public $latitud, $longitud;
     public $model, $id;
     protected $listeners = ['refreshDireccion' => 'refreshDireccion'];
 
     public function mount($id)
     {
-        // $this->id= $id;
-        // $obra = Obra::find($id);
-        // $this->model =  $obra->detalle;
-        // $this->calle = $this->model->direccion->calle;
-        // $this->manzana = $this->model->direccion->manzana;
-        // $this->lote = $this->model->direccion->lote;
-        // $this->paisSeleccionado = $this->model->direccion->pais->id;
-        // $this->estadoSeleccionado = $this->model->direccion->estado->id;
-        // $this->metrosCuadrados = $this->model->direccion->metrosCuadrados;
-        // $this->fraccionamiento = $this->model->direccion->fraccionamiento;
-        // $this->nombreObra = $this->model->nombreObra;
-        // $this->total = $this->model->total;
-        // //$this->moneda = $this->model->moneda;
-        // $this->fechaInicio = $this->model->fechaInicio;
-        // $this->fechaFin = $this->model->fechaFin;
-        // //$this->dictamenUsoSuelo = $this->model->dictamenUsoSuelo;
-        // $this->paises = Pais::all();
-        // $this->estadosObra = EstadoObra::all();
-        // $this->estadoObraSeleccionado= $this->model->obra->estado->id;
-        // $this->estados = [];
         $this->id = $id;
         $obra = Obra::find($id);
         $this->model = $obra->detalle;
@@ -55,8 +35,9 @@ class EditarDetalleObra extends ServicesComponent
             $this->estadoSeleccionado = $this->model->direccion->estado->id ?? null;
             $this->metrosCuadrados = $this->model->direccion->metrosCuadrados ?? null;
             $this->fraccionamiento = $this->model->direccion->fraccionamiento ?? null;
+            $this->latitud = $this->model->direccion->latitud ?? null;
+            $this->longitud = $this->model->direccion->longitud ?? null;
         }
-
         // Resto de las propiedades
         $this->nombreObra = $this->model->nombreObra;
         $this->total = $this->model->total;
@@ -67,23 +48,16 @@ class EditarDetalleObra extends ServicesComponent
 
         // Cargar los países y estados de obra
         $this->paises = Pais::all();
+        $this->estados = Estado::all();
+
         $this->estadosObra = EstadoObra::all();
         $this->estadoObraSeleccionado = $this->model->obra->estado->id ?? null;
-        $this->estados = [];
 
     }
 
     public function render()
     {
         return view('livewire.detalles-obras.editar-detalle-obra');
-    }
-
-    public function cambiar()
-    {
-        if ($this->paisSeleccionado) {
-            $this->estados = Estado::where('idPais', $this->paisSeleccionado)->get();
-        }
-        $this->estadoSeleccionado = null;
     }
 
     public function editarDetalleObra()
@@ -99,23 +73,24 @@ class EditarDetalleObra extends ServicesComponent
             'lote'=> 'nullable|string',
             'metrosCuadrados'=> 'nullable|numeric',
             'fraccionamiento'=> 'required|string',
+
             //'dictamenUsoSuelo'=> 'nullable|string',
             'paisSeleccionado' => 'nullable|exists:paises,id',
             'estadoSeleccionado' => 'nullable|exists:estados,id',
             'estadoObraSeleccionado' => 'nullable|exists:estadoobra,id',
         ]);
         try{
+            $this->latitud = substr($this->latitud, 0, -1);
+            $this->longitud = substr($this->longitud, 0, -1);
             $user = Auth::user();
             DetalleObra::editarDetalleObra(
             $this->model->id, $this->nombreObra, $this->total,$this->moneda,$this->fechaInicio, $this->fechaFin,$this->dictamenUsoSuelo,
             $this->estadoObraSeleccionado,
-            $this->calle,$this->manzana,$this->lote,$this->metrosCuadrados, $this->fraccionamiento,$this->estadoSeleccionado, $this->paisSeleccionado,
+            $this->calle,$this->manzana,$this->lote,$this->metrosCuadrados, $this->fraccionamiento,$this->estadoSeleccionado, $this->paisSeleccionado, $this->latitud, $this->longitud,
             $user->id);
-
-            //$this->dispatch('refreshClientesTable')->to(ClientesTable::class);
             $this->render();
-            //$this->dispatch( 'recargarMapa', $this->model->id);
-            // $this->limpiar();
+            // Emitir evento para recargar el mapa con las nuevas coordenadas
+            //$this->dispatch('refreshMapa', $this->latitud, $this->longitud);
             $this->alertService->success($this, 'Detalle Obra editado con éxito');
         } catch (\Exception $th) {
             $this->alertService->error($this, 'Error al actualizar la obra');
@@ -123,10 +98,11 @@ class EditarDetalleObra extends ServicesComponent
         }
     }
 
-    public function refreshDireccion($calle, $estado, $pais)
+    public function refreshDireccion($calle, $estado, $pais, $latitud, $longitud)
     {
-
         $this->calle = $calle;
+        $this->latitud = $latitud."s";
+        $this->longitud = $longitud."s";
         // Busca el ID del estado sin importar mayúsculas o minúsculas
         $estadoEncontrado = Estado::whereRaw('LOWER(nombre) = ?', [strtolower($estado)])->first();
         if ($estadoEncontrado) {

--- a/app/Models/DetalleObra.php
+++ b/app/Models/DetalleObra.php
@@ -62,7 +62,7 @@ class DetalleObra extends Model
     static function editarDetalleObra(
     $id, $nombreObra, $total,$moneda,$fechaInicio, $fechaFin,$dictamenUsoSuelo,
     $estadoObra,
-    $calle,$manzana,$lote,$metrosCuadrados, $fraccionamiento,$estado, $pais,
+    $calle,$manzana,$lote,$metrosCuadrados, $fraccionamiento,$estado, $pais, $latitud,$longitud,
     $userId)
     {
         try {
@@ -88,6 +88,8 @@ class DetalleObra extends Model
             $detalleObra->direccion->fraccionamiento = $fraccionamiento;
             $detalleObra->direccion->idPais = $pais;
             $detalleObra->direccion->idEstado = $estado;
+            $detalleObra->direccion->latitud = $latitud;
+            $detalleObra->direccion->longitud = $longitud;
             $detalleObra->direccion->save();
 
             // Finalmente guarda el `detalleObra`

--- a/app/Models/DireccionObra.php
+++ b/app/Models/DireccionObra.php
@@ -21,6 +21,8 @@ class DireccionObra extends Model
         'calle',
         'manzana',
         'lote',
+        'latitud',
+        'longitud',
         'metrosCuadrados',
         'fraccionamiento',
         'idPais',
@@ -30,12 +32,14 @@ class DireccionObra extends Model
         'deleted_by',
     ];
 
-    static function crearDireccionObra($calle, $manzana,$lote, $metrosCuadrados,$fraccionamiento, $idPais,$idEstado, $userId)
+    static function crearDireccionObra($calle, $manzana,$lote, $metrosCuadrados,$fraccionamiento, $idPais,$idEstado, $latitud,$longitud, $userId)
     {
         $estado = new DireccionObra();
         $estado->calle = $calle;
         $estado->manzana =$manzana;
         $estado->lote = $lote;
+        $latitud->manzana =$latitud;
+        $longitud->lote = $longitud;
         $estado->metrosCuadrados =$metrosCuadrados;
         $estado->fraccionamiento = $fraccionamiento;
         $estado->idPais =$idPais;
@@ -47,12 +51,14 @@ class DireccionObra extends Model
     }
 
 
-    static function editarDireccionObra($id, $calle, $manzana,$lote, $metrosCuadrados,$fraccionamiento, $idPais,$idEstado, $userId)
+    static function editarDireccionObra($id, $calle, $manzana,$lote, $metrosCuadrados,$fraccionamiento, $idPais,$idEstado,$latitud,$longitud, $userId)
     {
         $estado = DireccionObra::findOrfail($id);
         $estado->calle = $calle;
         $estado->manzana =$manzana;
         $estado->lote = $lote;
+        $latitud->manzana =$latitud;
+        $longitud->lote = $longitud;
         $estado->metrosCuadrados =$metrosCuadrados;
         $estado->fraccionamiento = $fraccionamiento;
         $estado->idPais =$idPais;

--- a/app/Models/Obra.php
+++ b/app/Models/Obra.php
@@ -149,7 +149,7 @@ class Obra extends Model
     // relación con el modelo detalle Obra
     public function detalle()
     {
-        return $this->belongsTo(DetalleObra::class, 'idDetalleObra');
+        return $this->belongsTo(DetalleObra::class, 'idDetalleObra')->with('direccion');
     }
     // relación con el modelo cliente
     public function cliente()

--- a/resources/views/livewire/detalles-obras/detalles-obras-table.blade.php
+++ b/resources/views/livewire/detalles-obras/detalles-obras-table.blade.php
@@ -34,9 +34,11 @@
                     <livewire:documentos-obras.eliminar-documento-obra  />
                 </div>
             </div>
-            <div class="tab-pane fade" id="ex-with-icons-tabs-3" role="tabpanel" aria-labelledby="ex-with-icons-tab-3">
-                <div style="margin:2rem">
-                    <div id="map" style="height: 400px; width: 100%;"></div>
+            <div  wire:ignore>
+                <div class="tab-pane fade" id="ex-with-icons-tabs-3" role="tabpanel" aria-labelledby="ex-with-icons-tab-3" >
+                    <div style="margin:2rem; justify-content: center">
+                        <div id="map" style="height: 400px; width: 100%;"></div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -80,15 +82,16 @@
         let marker;
         let leafletMap;
 
-        // Escuchar el evento de cambiar la pestaña y asegurarse de que el mapa se inicializa solo una vez
-        // document.querySelector('a[href="#ex-with-icons-tabs-3"]').addEventListener('shown.bs.tab', function () {
+        // Evento al cambiar a la pestaña del mapa
+        document.querySelector('a[href="#ex-with-icons-tabs-3"]').addEventListener('shown.bs.tab', function () {
+            if (leafletMap) {
+                leafletMap.invalidateSize();  // Forzar redimensionamiento al cambiar de pestaña
+            }
+        });
 
-        // });
-        function manejarCambioDePestana() {
+        // Inicializar el mapa si no está ya inicializado
+        function initializeMap(lat, lng) {
             if (!mapInitialized) {
-                const lat = @json($lat);
-                const lng = @json($lng);
-
                 if (lat === null || lng === null) {
                     console.error('Las coordenadas son nulas. No se puede inicializar el mapa.');
                     return;
@@ -102,7 +105,7 @@
                     return;
                 }
 
-                // Inicializa el mapa centrado en las coordenadas obtenidas por la dirección
+                // Inicializa el mapa centrado en las coordenadas obtenidas
                 leafletMap = L.map('map').setView([latitude, longitude], 13);
 
                 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -126,37 +129,34 @@
                         lat: newLat,
                         lng: newLng
                     });
+
+                    //  // Forzar redimensionamiento del mapa cuando se muestra
+                    // leafletMap.invalidateSize();
+                    // mapInitialized = true;
+
                 });
-                // Forzar redimensionamiento del mapa cuando se muestra
-                leafletMap.invalidateSize();
-                mapInitialized = true;
             }
         }
 
-        document.querySelector('a[href="#ex-with-icons-tabs-3"]').addEventListener('shown.bs.tab', function () {
-            // Invoca la función manejarCambioDePestana cuando se muestra la pestaña
-            manejarCambioDePestana();
-        });
-
-        // Escuchar eventos de actualización desde Livewire si es necesario
+        // Maneja la actualización del mapa cuando se guardan nuevas coordenadas
         Livewire.on('updateMap', (data) => {
-             // Seleccionar y mostrar el Tab 1 antes de crear el mapa
-            mostrarTab1();
+            const latitude = data[0].coordenadas.latitud;
+            const longitude = data[0].coordenadas.longitud;
 
-            if (mapInitialized && marker && leafletMap) {
-                const latitude = data[0]['coordenadas'].latitud;
-                const longitude = data[0]['coordenadas'].longitud;
-                leafletMap.remove();
-                mapInitialized = false;
-                const mapContainer = document.getElementById('map');
-
-
+            if (mapInitialized && marker) {
+                // Mueve el marcador a la nueva posición
+                marker.setLatLng([latitude, longitude]).update();
+                leafletMap.setView([latitude, longitude], 13);  // Centrar el mapa en las nuevas coordenadas
+                leafletMap.invalidateSize();  // Redimensionar el mapa
             }
         });
-        // Livewire.on('recargar', ()=> {
-        //     mostrarTab1()
-        // });
+
+        // Inicializar el mapa al cargar el componente
+        const lat = @json($lat);
+        const lng = @json($lng);
+        initializeMap(lat, lng);
     });
+
 
 </script>
 @endpush

--- a/resources/views/livewire/detalles-obras/editar-detalle-obra.blade.php
+++ b/resources/views/livewire/detalles-obras/editar-detalle-obra.blade.php
@@ -99,6 +99,9 @@
                         @error('fraccionamiento') <span class="text-danger">{{ $message }}</span> @enderror
                     </div>
                 </div>
+                <!-- Campos ocultos de latitud y longitud -->
+                <input type="text" wire:model="latitud" hidden>
+                <input type="text" wire:model="longitud" hidden>
                 {{-- <div class="col-md-3">
                     <div class="form-group">
                         <label for="dictamenUsoSuelo">Dictamen Uso Suelo</label>
@@ -110,7 +113,7 @@
                 <!-- Cuarta fila -->
                 <div class="col-md-3">
                     <label for="paises">País</label>
-                    <select wire:model="paisSeleccionado" wire:change="cambiar" class="form-control" id="select2Paises">
+                    <select wire:model="paisSeleccionado" class="form-control" id="select2Paises">
                         <option value="" selected hidden >Seleccione un Pais</option>
                         @foreach ($paises as $pais)
                             <option value="{{ $pais->id }}">{{ $pais->nombre }}</option>
@@ -120,8 +123,8 @@
                 </div>
                 <!-- Campo Estado -->
                 <div class="col-md-3">
-                    <label for="estados">Estado</label>
-                    <select wire:model="estadoSeleccionado" class="form-control" id="select2Estados">
+                    <label for="estados">Estados</label>
+                    <select wire:model="estadoSeleccionado" class="form-control">
                         <option value="" selected hidden >Seleccione un Estado</option>
                         @foreach ($estados as $estado)
                             <option value="{{ $estado->id }}">{{ $estado->nombre }}</option>

--- a/resources/views/pdf/recibo/firmarRecibo.blade.php
+++ b/resources/views/pdf/recibo/firmarRecibo.blade.php
@@ -102,6 +102,54 @@
         var isSaved = false;  // Variable para controlar si la firma ha sido guardada
         var isEmpty = true;   // Variable para controlar si el canvas está vacío
 
+        canvas.addEventListener("touchstart", startDrawing, false);
+        canvas.addEventListener("touchmove", draw, false);
+        canvas.addEventListener("touchend", stopDrawing, false);
+        canvas.addEventListener("touchcancel", stopDrawing, false);
+
+        function startDrawing(event) {
+            drawing = true;
+            const rect = canvas.getBoundingClientRect();
+            const clientX = event.touches ? event.touches[0].clientX : event.clientX;
+            const clientY = event.touches ? event.touches[0].clientY : event.clientY;
+
+            // Ajustar la escala del canvas según la densidad de píxeles
+            const scaleX = canvas.width / rect.width;
+            const scaleY = canvas.height / rect.height;
+
+            const x = (clientX - rect.left) * scaleX;
+            const y = (clientY - rect.top) * scaleY;
+
+            ctx.beginPath();
+            ctx.moveTo(x, y);
+            event.preventDefault();
+        }
+
+        function draw(event) {
+            if (!drawing) return;
+            const rect = canvas.getBoundingClientRect();
+            const clientX = event.touches ? event.touches[0].clientX : event.clientX;
+            const clientY = event.touches ? event.touches[0].clientY : event.clientY;
+
+            // Ajustar la escala del canvas según la densidad de píxeles
+            const scaleX = canvas.width / rect.width;
+            const scaleY = canvas.height / rect.height;
+
+            const x = (clientX - rect.left) * scaleX;
+            const y = (clientY - rect.top) * scaleY;
+
+            ctx.lineTo(x, y);
+            ctx.stroke();
+            event.preventDefault();
+        }
+
+        function stopDrawing(event) {
+            if (!drawing) return;
+            drawing = false;
+            ctx.closePath();
+            event.preventDefault();
+        }
+
        // Obtener la posición exacta del mouse relativa al canvas
         function getMousePos(canvas, evt) {
             var rect = canvas.getBoundingClientRect();

--- a/resources/views/pdf/recibo/firmarRecibo.blade.php
+++ b/resources/views/pdf/recibo/firmarRecibo.blade.php
@@ -102,11 +102,23 @@
         var isSaved = false;  // Variable para controlar si la firma ha sido guardada
         var isEmpty = true;   // Variable para controlar si el canvas está vacío
 
+       // Obtener la posición exacta del mouse relativa al canvas
+        function getMousePos(canvas, evt) {
+            var rect = canvas.getBoundingClientRect();
+            var scaleX = canvas.width / rect.width;   // Relación de escalado horizontal
+            var scaleY = canvas.height / rect.height; // Relación de escalado vertical
+            return {
+                x: (evt.clientX - rect.left) * scaleX,
+                y: (evt.clientY - rect.top) * scaleY
+            };
+        }
+
         // Comenzar a dibujar
         canvas.addEventListener('mousedown', function(e) {
             if (!isSaved) {
                 drawing = true;
-                ctx.moveTo(e.offsetX, e.offsetY);
+                var pos = getMousePos(canvas, e);
+                ctx.moveTo(pos.x, pos.y);
                 isEmpty = false;  // Marcamos que el canvas ya no está vacío
             }
         });
@@ -114,7 +126,8 @@
         // Continuar dibujando
         canvas.addEventListener('mousemove', function(e) {
             if (drawing && !isSaved) {
-                ctx.lineTo(e.offsetX, e.offsetY);
+                var pos = getMousePos(canvas, e);
+                ctx.lineTo(pos.x, pos.y);
                 ctx.stroke();
             }
         });
@@ -123,6 +136,7 @@
         canvas.addEventListener('mouseup', function() {
             drawing = false;
         });
+
 
         // Limpiar el canvas
         document.getElementById('clearSignature').addEventListener('click', function() {


### PR DESCRIPTION
se mejora el mapa se agrega latitud y longitud en la bd en la tabla direcciones y que sean varchar para guardar cada digito, al cargar el mapa se pregunta si tiene una latitud y longitud se va a mostrar ese dato en el mapaa seleccionado sino va a obtener la latitud y longitd con la calle estado y pais.
se mejoro la firma para que funcione en celulares con tactil y en escritorio con mouse y se mejoro la precision.